### PR TITLE
feat(time): support RFC3339 dates

### DIFF
--- a/time/time.go
+++ b/time/time.go
@@ -27,9 +27,12 @@ func (t *Time) MarshalJSON() ([]byte, error) {
 // UnmarshalText implements the encoding.TextUnmarshaler interface.
 // The time is expected to be in Deis' datetime format.
 func (t *Time) UnmarshalText(data []byte) error {
-	tt, err := time.Parse(DeisDatetimeFormat, string(data))
+	tt, err := time.Parse(time.RFC3339, string(data))
 	if _, ok := err.(*time.ParseError); ok {
-		tt, err = time.Parse(PyOpenSSLTimeDateTimeFormat, string(data))
+		tt, err = time.Parse(DeisDatetimeFormat, string(data))
+		if _, ok := err.(*time.ParseError); ok {
+			tt, err = time.Parse(PyOpenSSLTimeDateTimeFormat, string(data))
+		}
 	}
 	*t = Time{&tt}
 	return err
@@ -39,9 +42,12 @@ func (t *Time) UnmarshalText(data []byte) error {
 // The time is expected to be a quoted string in Deis' datetime format.
 func (t *Time) UnmarshalJSON(data []byte) error {
 	// Fractional seconds are handled implicitly by Parse.
-	tt, err := time.Parse(`"`+DeisDatetimeFormat+`"`, string(data))
+	tt, err := time.Parse(`"`+time.RFC3339+`"`, string(data))
 	if _, ok := err.(*time.ParseError); ok {
-		tt, err = time.Parse(`"`+PyOpenSSLTimeDateTimeFormat+`"`, string(data))
+		tt, err = time.Parse(`"`+DeisDatetimeFormat+`"`, string(data))
+		if _, ok := err.(*time.ParseError); ok {
+			tt, err = time.Parse(`"`+PyOpenSSLTimeDateTimeFormat+`"`, string(data))
+		}
 	}
 	*t = Time{&tt}
 	return err

--- a/time/time_test.go
+++ b/time/time_test.go
@@ -12,6 +12,7 @@ func TestUnMarshalText(t *testing.T) {
 		"2006-01-02T15:04:05MST",
 		"2006-01-02T15:04:05UTC",
 		"2006-01-02T15:04:05PST",
+		"2006-01-02T15:04:05Z",
 	}
 	for _, goodTime := range standardTimeFormats {
 		if dummyTime.UnmarshalText([]byte(goodTime)) != nil {


### PR DESCRIPTION
k8s returns dates with `Z` timezone identifier (Zulu) which is the same as UTC defined in ISO8061 which RFC3339 is part of
