### PR TITLE
feat(travis): add Go 1.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 sudo: required
 go:
   - 1.5
-  - tip
+  - 1.6
 env:
   - GO15VENDOREXPERIMENT=1
 install:


### PR DESCRIPTION
This removes `go tip` support, since tip is under very active dev right
now. It's already broken at least one build.
