### PR TITLE
fix(.travis.yml): test with go 1.5 and 1.6, not tip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: go
 sudo: required
 go:
   - 1.5
-  - tip
+  - 1.6
 env:
   - GO15VENDOREXPERIMENT=1
 install:


### PR DESCRIPTION
The .travis.yml configuration file specified `tip`, but Go 1.7 is a faraway dream which removed the `GO15VENDOREXPERIMENT` flag and thus breaks the build. Specify Go 1.5 and 1.6 instead.
