### PR TITLE
feat(log): add SetStdout() and SetStderr()

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -53,9 +53,19 @@ func NewLogger(stdout, stderr io.Writer, debug bool) *Logger {
 // DefaultLogger is the default logging implementation. It's used in all top level funcs inside the log package, and represents the equivalent of NewLogger(os.Stdout, os.Stderr)
 var DefaultLogger = &Logger{stdout: os.Stdout, stderr: os.Stderr, debug: false}
 
-// SetDebug sets the internal debugging field on or off. This func is not concurrency safe
+// SetDebug sets the internal debugging field on or off. This func is not concurrency safe.
 func (l *Logger) SetDebug(debug bool) {
 	l.debug = debug
+}
+
+// SetStdout sets the internal stdout writer. This func is not concurrency safe.
+func (l *Logger) SetStdout(w io.Writer) {
+	l.stdout = w
+}
+
+// SetStderr sets the internal stderr writer. This func is not concurrency safe.
+func (l *Logger) SetStderr(w io.Writer) {
+	l.stderr = w
 }
 
 // Msg passes through the formatter, but otherwise prints exactly as-is.

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -64,3 +64,18 @@ func TestAppendNewLine(t *testing.T) {
 	newStr := appendNewLine(str)
 	assert.Equal(t, newStr, str+"\n", "new string")
 }
+
+func TestDefaultLoggerSetStdout(t *testing.T) {
+	var b bytes.Buffer
+	DefaultLogger.SetStdout(&b)
+	Warn("hello world")
+	assert.Equal(t, b.String(), "hello world\n", "stdout output")
+}
+
+func TestDefaultLoggerSetStderr(t *testing.T) {
+	var b bytes.Buffer
+	DefaultLogger.SetStderr(&b)
+	DefaultLogger.SetDebug(true)
+	Debug("hello world")
+	assert.Equal(t, b.String(), addColor(DebugPrefix+" ", Cyan), "stderr output")
+}


### PR DESCRIPTION
This new feature allows users to change the Stdout and Stderr writers for the DefaultLogger
on-the-fly, allowing them to test log output based on certain input from the user.

refs work being done in https://github.com/deis/builder/pull/437
